### PR TITLE
Updating docker file to not live in the root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,12 +9,13 @@ RUN apk add --update \
   && rm -rf /var/cache/apk/*
 
 RUN mkdir -p $HOME/service/toga
-
-COPY . $HOME/service/toga
-
 WORKDIR $HOME/service/toga
+
+COPY package.json ./
+
 RUN npm install --production
-RUN ln -sfn /config/newrelic.js $HOME/newrelic.js
+
+COPY . ./
 
 ENV NODE_ENV=production
 EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,13 @@ RUN apk add --update \
     build-base \
   && rm -rf /var/cache/apk/*
 
-COPY package.json $HOME/
+RUN mkdir -p $HOME/service/toga
 
+COPY . $HOME/service/toga
+
+WORKDIR $HOME/service/toga
 RUN npm install --production
 RUN ln -sfn /config/newrelic.js $HOME/newrelic.js
-
-COPY . $HOME/
 
 ENV NODE_ENV=production
 EXPOSE 8080

--- a/DockerfileDev
+++ b/DockerfileDev
@@ -8,12 +8,14 @@ RUN apk add --update \
     build-base \
   && rm -rf /var/cache/apk/*
 
-COPY package.json $HOME/
+RUN mkdir -p $HOME/service/toga
+WORKDIR $HOME/service/toga
+
+COPY package.json ./
 
 RUN npm install
-RUN ln -sfn /config/newrelic.js $HOME/newrelic.js
 
-COPY . $HOME/
+COPY . ./
 
 EXPOSE 8080
 CMD npm run dev -- --config './app/config/dockerOverrides.json'

--- a/components/HelloWorld/index.js
+++ b/components/HelloWorld/index.js
@@ -74,4 +74,3 @@ export default class HelloWorld extends React.Component {
     );
   }
 }
-

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -9,9 +9,9 @@ services:
       - 8080:8080
       - 3001:3001
     volumes:
-      - ./app:/app
-      - ./components:/components
-      - ./script:/script
+      - ./app:/service/toga/app
+      - ./components:/service/toga/components
+      - ./script:/service/toga/script
     links:
       - redis
   redis:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,9 +7,9 @@ services:
     ports:
       - 8080:8080
     volumes:
-      - ./app:/app
-      - ./components:/components
-      - ./script:/script
+      - ./app:/service/toga/app
+      - ./components:/service/toga/components
+      - ./script:/service/toga/script
     links:
       - redis
     environment:


### PR DESCRIPTION
Creates some issues with paths in webpack and/or isomorphic-tools as it makes the path absolute. Moving it into its own 'toga' directory fixes it 