### PR TITLE
Etag support

### DIFF
--- a/app/createServer.js
+++ b/app/createServer.js
@@ -7,13 +7,27 @@ module.exports = (deps) => {
       '/routes/index': getRoutes,
       '/middleware/errorHandler': errorHandler,
       '/middleware/logRequests': logRequests,
+      '/lib/getComponentInfo': getComponentInfo,
+      '/lib/bundler/buildHash': buildHash,
       compression
     } = deps;
     const app = express();
 
+    const componentInfo = getComponentInfo(['vendor']);
+    const hash = buildHash([componentInfo.root])
+
     hook.hook('.scss', () => {});
     app.set('Accept-Encoding', 'gzip');
+    app.set('etag', () => hash);
     app.use(logRequests); //be first to ensure all requests are logged
+    app.use((req, res, next) => {
+      if(req.get('If-None-Match') === hash) {
+        res.sendStatus(304)
+      }
+      else {
+        next()
+      }
+    });
     app.use(compression());
     app.use(domainMiddleware);
     app.use(getRoutes());

--- a/app/createServer.js
+++ b/app/createServer.js
@@ -7,27 +7,16 @@ module.exports = (deps) => {
       '/routes/index': getRoutes,
       '/middleware/errorHandler': errorHandler,
       '/middleware/logRequests': logRequests,
-      '/lib/getComponentInfo': getComponentInfo,
-      '/lib/bundler/buildHash': buildHash,
+      '/middleware/etagCache': etagCache,
       compression
     } = deps;
     const app = express();
 
-    const componentInfo = getComponentInfo(['vendor']);
-    const hash = buildHash([componentInfo.root])
-
     hook.hook('.scss', () => {});
     app.set('Accept-Encoding', 'gzip');
-    app.set('etag', () => hash);
+    app.set('etag', etagCache.returnHash);
     app.use(logRequests); //be first to ensure all requests are logged
-    app.use((req, res, next) => {
-      if(req.get('If-None-Match') === hash) {
-        res.sendStatus(304)
-      }
-      else {
-        next()
-      }
-    });
+    app.use(etagCache.etagRequest);
     app.use(compression());
     app.use(domainMiddleware);
     app.use(getRoutes());

--- a/app/middleware/etagCache.js
+++ b/app/middleware/etagCache.js
@@ -1,7 +1,7 @@
 module.exports = (deps) => {
   const {
     '/lib/getComponentInfo': getComponentInfo,
-    '/lib/bundler/buildHash': buildHash,
+    '/lib/bundler/buildHash': buildHash
   } = deps;
 
   const componentInfo = getComponentInfo();

--- a/app/middleware/etagCache.js
+++ b/app/middleware/etagCache.js
@@ -1,0 +1,22 @@
+module.exports = (deps) => {
+  const {
+    '/lib/getComponentInfo': getComponentInfo,
+    '/lib/bundler/buildHash': buildHash,
+  } = deps;
+
+  const componentInfo = getComponentInfo();
+  const hash = buildHash([componentInfo[0].root]);
+
+  const returnHash = () => hash;
+
+  const etagRequest = (req, res, next) => {
+    if(req.get('If-None-Match') === hash) {
+      res.sendStatus(304);
+    }
+    else {
+      next();
+    }
+  };
+
+  return { etagRequest, returnHash };
+};

--- a/tests/spec/app/middleware/etagCache.spec.js
+++ b/tests/spec/app/middleware/etagCache.spec.js
@@ -47,6 +47,7 @@ describe('etagCache', () => {
       etagRequest(fakeRequest, fakeResponse, nextStub);
 
       expect(sendStatusStub).to.be.calledWith(304);
+      expect(reqGetStub).to.be.calledWith('If-None-Match');
       expect(nextStub).to.not.have.been.called;
     });
 

--- a/tests/spec/app/middleware/etagCache.spec.js
+++ b/tests/spec/app/middleware/etagCache.spec.js
@@ -1,0 +1,59 @@
+const expect = require('chai').expect;
+const sinon = require('sinon');
+const builder = require('../../../../app/middleware/etagCache');
+const Chance = require('chance');
+const chance = new Chance();
+
+const sandbox = sinon.sandbox.create();
+const getComponentInfoStub = sandbox.stub();
+const buildHashStub = sandbox.stub();
+const hash = chance.word();
+const components = ['1'];
+getComponentInfoStub.returns(components);
+buildHashStub.returns(hash);
+const reqGetStub = sandbox.stub().returns(hash);
+
+const fakeRequest = {
+  get: reqGetStub
+};
+
+const sendStatusStub = sandbox.stub();
+const fakeResponse = {
+  sendStatus: sendStatusStub
+};
+const nextStub = sandbox.stub();
+
+const subject = builder({
+  '/lib/getComponentInfo': getComponentInfoStub,
+  '/lib/bundler/buildHash': buildHashStub
+});
+
+describe('etagCache', () => {
+
+  afterEach(() => {
+    sandbox.reset();
+  });
+
+  context('returnHash', () => {
+    it('returns function returning hash', () => {
+      expect(subject.returnHash()).to.eq(hash);
+    });
+  });
+
+  context('etagRequest', () => {
+    const etagRequest = subject.etagRequest;
+
+    it('when header matches hash', () => {
+      etagRequest(fakeRequest, fakeResponse, nextStub);
+
+      expect(sendStatusStub).to.be.calledWith(304);
+      expect(nextStub).to.not.have.been.called;
+    });
+
+    it('when header does not matches hash', () => {
+      reqGetStub.returns(undefined);
+      etagRequest(fakeRequest, fakeResponse, nextStub);
+      expect(nextStub).to.have.been.calledOnce;
+    });
+  });
+});


### PR DESCRIPTION
- Set the etag to be the hash of the components
- On requests check if `If-None-Match` header matches hash return 304