### PR TITLE
add webpack-visualizer-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,13 @@ One Toga is running and you can hit the component endpoint, user the query `?pro
 `http://localhost:8080/HelloWorld.html?props={"world":"waynes"}`
 
 
+## Analysing your build
+
+Once you have created your bundle (`npm run bundle -- --components=./components-dir`), a web-page will be generated which allows you to see what files are included in your bundles.
+This allows you to see if a small library is accidentally bloating your package.
+
+it will be generated in : `/dist/webpack-components-stats.html`
+
 ## Contributing
 
  > More information about how to contribute and run the project locally.

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -42,6 +42,11 @@
       "from": "alphanum-sort@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz"
     },
+    "amdefine": {
+      "version": "1.0.1",
+      "from": "amdefine@>=0.0.4",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
+    },
     "ansi-regex": {
       "version": "2.1.1",
       "from": "ansi-regex@>=2.0.0 <3.0.0",
@@ -131,6 +136,11 @@
       "version": "3.5.0",
       "from": "assets-webpack-plugin@>=3.5.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/assets-webpack-plugin/-/assets-webpack-plugin-3.5.0.tgz"
+    },
+    "ast-types": {
+      "version": "0.9.2",
+      "from": "ast-types@0.9.2",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.2.tgz"
     },
     "async": {
       "version": "1.5.2",
@@ -467,6 +477,11 @@
       "from": "balanced-match@>=0.4.1 <0.5.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
     },
+    "base62": {
+      "version": "1.1.2",
+      "from": "base62@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/base62/-/base62-1.1.2.tgz"
+    },
     "base64-js": {
       "version": "1.2.0",
       "from": "base64-js@>=1.0.2 <2.0.0",
@@ -514,21 +529,9 @@
       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz"
     },
     "breadboard": {
-      "version": "9.0.2",
+      "version": "9.0.3",
       "from": "breadboard@>=9.0.2 <10.0.0",
-      "resolved": "https://registry.npmjs.org/breadboard/-/breadboard-9.0.2.tgz",
-      "dependencies": {
-        "debug": {
-          "version": "2.2.0",
-          "from": "debug@2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
-        },
-        "ms": {
-          "version": "0.7.1",
-          "from": "ms@0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz"
-        }
-      }
+      "resolved": "https://registry.npmjs.org/breadboard/-/breadboard-9.0.3.tgz"
     },
     "brorand": {
       "version": "1.0.6",
@@ -739,6 +742,11 @@
       "from": "commondir@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz"
     },
+    "commoner": {
+      "version": "0.10.8",
+      "from": "commoner@>=0.10.1 <0.11.0",
+      "resolved": "https://registry.npmjs.org/commoner/-/commoner-0.10.8.tgz"
+    },
     "compressible": {
       "version": "2.0.9",
       "from": "compressible@>=2.0.8 <2.1.0",
@@ -905,6 +913,11 @@
       "from": "currently-unhandled@>=0.4.1 <0.5.0",
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz"
     },
+    "d3": {
+      "version": "3.5.17",
+      "from": "d3@>=3.5.6 <4.0.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-3.5.17.tgz"
+    },
     "dashdash": {
       "version": "1.14.1",
       "from": "dashdash@>=1.12.0 <2.0.0",
@@ -977,6 +990,18 @@
       "from": "detect-indent@>=4.0.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz"
     },
+    "detective": {
+      "version": "4.3.2",
+      "from": "detective@>=4.3.1 <5.0.0",
+      "resolved": "https://registry.npmjs.org/detective/-/detective-4.3.2.tgz",
+      "dependencies": {
+        "acorn": {
+          "version": "3.3.0",
+          "from": "acorn@>=3.1.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz"
+        }
+      }
+    },
     "diffie-hellman": {
       "version": "5.0.2",
       "from": "diffie-hellman@>=5.0.0 <6.0.0",
@@ -1033,6 +1058,11 @@
       "version": "1.1.1",
       "from": "entities@>=1.1.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
+    },
+    "envify": {
+      "version": "3.4.1",
+      "from": "envify@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/envify/-/envify-3.4.1.tgz"
     },
     "errno": {
       "version": "0.1.4",
@@ -1266,11 +1296,6 @@
           "optional": true
         }
       }
-    },
-    "formatio": {
-      "version": "1.1.1",
-      "from": "formatio@1.1.1",
-      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.1.1.tgz"
     },
     "forwarded": {
       "version": "0.1.0",
@@ -2463,6 +2488,28 @@
       "from": "jsprim@>=1.2.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz"
     },
+    "jstransform": {
+      "version": "11.0.3",
+      "from": "jstransform@>=11.0.3 <12.0.0",
+      "resolved": "https://registry.npmjs.org/jstransform/-/jstransform-11.0.3.tgz",
+      "dependencies": {
+        "esprima-fb": {
+          "version": "15001.1.0-dev-harmony-fb",
+          "from": "esprima-fb@>=15001.1.0-dev-harmony-fb <15002.0.0",
+          "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-15001.1.0-dev-harmony-fb.tgz"
+        },
+        "object-assign": {
+          "version": "2.1.1",
+          "from": "object-assign@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz"
+        },
+        "source-map": {
+          "version": "0.4.4",
+          "from": "source-map@>=0.4.2 <0.5.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz"
+        }
+      }
+    },
     "kind-of": {
       "version": "3.1.0",
       "from": "kind-of@>=3.0.2 <4.0.0",
@@ -2627,11 +2674,6 @@
       "version": "4.5.0",
       "from": "lodash.uniq@>=4.3.0 <5.0.0",
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz"
-    },
-    "lolex": {
-      "version": "1.3.2",
-      "from": "lolex@1.3.2",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.3.2.tgz"
     },
     "longest": {
       "version": "1.0.1",
@@ -3606,6 +3648,18 @@
       "from": "readdirp@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz"
     },
+    "recast": {
+      "version": "0.11.18",
+      "from": "recast@>=0.11.17 <0.12.0",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.11.18.tgz",
+      "dependencies": {
+        "esprima": {
+          "version": "3.1.3",
+          "from": "esprima@>=3.1.0 <3.2.0",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz"
+        }
+      }
+    },
     "rechoir": {
       "version": "0.6.2",
       "from": "rechoir@>=0.6.2 <0.7.0",
@@ -3817,11 +3871,6 @@
       "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.0.3.tgz",
       "optional": true
     },
-    "samsam": {
-      "version": "1.1.2",
-      "from": "samsam@1.1.2",
-      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.1.2.tgz"
-    },
     "sass-graph": {
       "version": "2.1.2",
       "from": "sass-graph@>=2.1.1 <3.0.0",
@@ -3934,11 +3983,6 @@
       "version": "0.1.1",
       "from": "simple-html-tokenizer@>=0.1.1 <0.2.0",
       "resolved": "https://registry.npmjs.org/simple-html-tokenizer/-/simple-html-tokenizer-0.1.1.tgz"
-    },
-    "sinon": {
-      "version": "1.17.3",
-      "from": "sinon@1.17.3",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.17.3.tgz"
     },
     "slash": {
       "version": "1.0.0",
@@ -4117,6 +4161,11 @@
       "from": "tar@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz"
     },
+    "through": {
+      "version": "2.3.8",
+      "from": "through@>=2.3.4 <2.4.0",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+    },
     "timers-browserify": {
       "version": "2.0.2",
       "from": "timers-browserify@>=2.0.2 <3.0.0",
@@ -4257,7 +4306,7 @@
     },
     "util": {
       "version": "0.10.3",
-      "from": "util@>=0.10.3 <1.0.0",
+      "from": "util@>=0.10.3 <0.11.0",
       "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
       "dependencies": {
         "inherits": {
@@ -4340,6 +4389,38 @@
       "version": "0.1.4",
       "from": "webpack-sources@>=0.1.0 <0.2.0",
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-0.1.4.tgz"
+    },
+    "webpack-visualizer-plugin": {
+      "version": "0.1.10",
+      "from": "webpack-visualizer-plugin@>=0.1.10 <0.2.0",
+      "resolved": "https://registry.npmjs.org/webpack-visualizer-plugin/-/webpack-visualizer-plugin-0.1.10.tgz",
+      "dependencies": {
+        "core-js": {
+          "version": "1.2.7",
+          "from": "core-js@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz"
+        },
+        "fbjs": {
+          "version": "0.6.1",
+          "from": "fbjs@>=0.6.1 <0.7.0",
+          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.6.1.tgz"
+        },
+        "react": {
+          "version": "0.14.8",
+          "from": "react@>=0.14.0 <0.15.0",
+          "resolved": "https://registry.npmjs.org/react/-/react-0.14.8.tgz"
+        },
+        "react-dom": {
+          "version": "0.14.8",
+          "from": "react-dom@>=0.14.0 <0.15.0",
+          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-0.14.8.tgz"
+        },
+        "whatwg-fetch": {
+          "version": "0.9.0",
+          "from": "whatwg-fetch@>=0.9.0 <0.10.0",
+          "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-0.9.0.tgz"
+        }
+      }
     },
     "whatwg-fetch": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "toga-loader": "github:notonthehighstreet/toga-loader#v1.0.3",
     "url-loader": "^0.5.7",
     "webpack": "^2.2.0",
+    "webpack-visualizer-plugin": "^0.1.10",
     "yargs": "^6.6.0"
   },
   "devDependencies": {

--- a/src/script/webpack/createWebpackConfig.js
+++ b/src/script/webpack/createWebpackConfig.js
@@ -1,5 +1,6 @@
 /* eslint-disable camelcase */
 
+const Visualizer = require('webpack-visualizer-plugin');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const AssetsPlugin = require('assets-webpack-plugin');
 const autoprefixer = require('autoprefixer');
@@ -54,6 +55,9 @@ module.exports = ({
     plugins: [
       new ProgressBarPlugin(),
       new webpack.HashedModuleIdsPlugin(),
+      new Visualizer({
+        filename: '../webpack-components-stats.html'
+      }),
       new webpack.optimize.CommonsChunkPlugin({ name: commonsChunkName, filename: '[name]-[chunkhash].js',  minChunks: Infinity}),
       new ExtractTextPlugin({ filename: '[name]-[contenthash].css', allChunks: true }),
       new webpack.LoaderOptionsPlugin({

--- a/src/script/webpack/createWebpackConfig.spec.js
+++ b/src/script/webpack/createWebpackConfig.spec.js
@@ -40,7 +40,7 @@ describe('Create Webpack Config', () => {
   it('creates a basic config', () => {
     const config = createWebpackConfig({
     });
-    expect(config.plugins.length).to.equal(6);
+    expect(config.plugins.length).to.equal(7);
   });
 
   it('has sourceMaps enabled', () => {


### PR DESCRIPTION
Outputs the html for the visualizer (to /dist/webpack-components-stats.html) so we don't even have to go online to see how are bundles are made!

<img width="826" alt="screen shot 2017-01-18 at 14 35 31" src="https://cloud.githubusercontent.com/assets/1727939/22070379/b367617a-dd93-11e6-877b-00b9b15aa9fa.png">
