### PR TITLE
Removing the exposing of garbage collector

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "pretest-e2e": "npm run preexample && npm run install:selenium",
     "install:selenium": "selenium-standalone install --version=2.53.1",
     "build": "NODE_ENV=production babel src -d dist",
-    "start": "DEBUG=toga,toga:* NODE_ENV=production node  --expose-gc ./dist/script/start/index.js --config ./app/config/application.js",
+    "start": "DEBUG=toga,toga:* NODE_ENV=production node ./dist/script/start/index.js --config ./app/config/application.js",
     "example": "TOGA_SERVER_PORT=3001 DEBUG=toga,toga:* node ./example --components=./tests/e2e",
     "heroku": "nodemon ./dist/script/start/index.js --config ./app/config/application.js --config ./app/config/herokuOverrides.js",
     "dev": "DEBUG=toga,toga:* TOGA_SOURCE=dev babel-node ./src/script/start/index.js --config ./app/config/application.js --config ./app/config/devOverrides.js",


### PR DESCRIPTION
As far as I remember this was because of the queue which went with webpack 2 so we no longer need to expose 