### PR TITLE
Skip render for non preview html files so they pass through to static…

### DIFF
--- a/src/app/middleware/getComponentHtml.js
+++ b/src/app/middleware/getComponentHtml.js
@@ -7,7 +7,11 @@ module.exports = (deps) => {
       '/views/component-test': renderTestMarkup,
       '/views/component-raw': renderRawMarkup
     } = deps;
-    const { props, raw, componentName } = req;
+    const { props, raw, preview, componentName } = req;
+    if (!raw && !preview) {
+      next();
+      return Promise.resolve();
+    }
     const renderer = raw ? renderRawMarkup : renderTestMarkup;
     return renderComponent({ componentName, props })
       .then((opts) => {
@@ -20,4 +24,3 @@ module.exports = (deps) => {
       });
   };
 };
-

--- a/src/app/middleware/getComponentHtml.spec.js
+++ b/src/app/middleware/getComponentHtml.spec.js
@@ -41,6 +41,7 @@ describe('getComponentRawHtml middleware', () => {
   it('passes props', () => {
     fakeReq.props = { [chance.word()]: chance.word() };
     fakeRes.set.returns(fakeRes);
+    fakeReq.preview = true;
     const result = subject(fakeReq, fakeRes, fakeNext);
     return result.then(()=> {
       expect(fakeRes.set).to.have.been.calledWith('Content-Type', 'text/html');
@@ -52,7 +53,7 @@ describe('getComponentRawHtml middleware', () => {
 
   it('responds with the rendered test component', () => {
     delete fakeReq.props;
-    fakeReq.raw = false;
+    fakeReq.preview = true;
     fakeRes.set.returns(fakeRes);
     const result = subject(fakeReq, fakeRes, fakeNext);
     return result.then(()=> {
@@ -72,6 +73,16 @@ describe('getComponentRawHtml middleware', () => {
       expect(fakeRes.send).to.have.been.calledWith(rawRenderResposne);
       expect(fakeRenderRawMarkup).to.have.been.calledWith({...fakeRenderOptions});
       expect(renderComponentStub).to.have.been.calledWith({ componentName, props: undefined});
+    });
+  });
+
+  it('calls next when a static asset', () => {
+    delete fakeReq.props;
+    fakeReq.preview = false;
+    fakeReq.raw = false;
+    const result = subject(fakeReq, fakeRes, fakeNext);
+    return result.then(()=> {
+      expect(fakeNext).to.have.been.calledOnce;
     });
   });
 });

--- a/src/app/middleware/setComponentProps.js
+++ b/src/app/middleware/setComponentProps.js
@@ -34,7 +34,8 @@ module.exports = (deps) => {
       req.componentName = req.params.componentName;
       req.props = parse(req.query.props, next);
       req.assetType = 'html';
-      req.raw = !!req.params[0];
+      req.raw = /raw/.test(req.params[0]);
+      req.preview = /preview/.test(req.params[0]);
       next();
     }
   };

--- a/src/app/middleware/setComponentProps.spec.js
+++ b/src/app/middleware/setComponentProps.spec.js
@@ -48,9 +48,16 @@ describe('setComponentProps', () => {
     });
 
     it('sets the raw to true', () => {
-      requestMock.params[0] = true;
+      requestMock.params[0] = 'raw';
       subject.html(requestMock, responseMock, nextSpy);
       expect(requestMock.raw).to.eq(true);
+      expect(nextSpy).to.have.been.calledOnce;
+    });
+
+    it('sets the preview to true', () => {
+      requestMock.params[0] = 'preview';
+      subject.html(requestMock, responseMock, nextSpy);
+      expect(requestMock.preview).to.eq(true);
       expect(nextSpy).to.have.been.calledOnce;
     });
 

--- a/src/app/routes/components.js
+++ b/src/app/routes/components.js
@@ -7,8 +7,8 @@ module.exports = (deps) => {
     } = deps;
     const router = express.Router();
 
-    router.use('/:componentName.(raw\.)?html', setComponentProps.html);
-    router.get('/:componentName.(raw\.)?html', getComponentHtml);
+    router.use('/:componentName.(raw\.|preview\.)?html', setComponentProps.html);
+    router.get('/:componentName.(raw\.|preview\.)?html', getComponentHtml);
 
     // needed for dev
     router.use('/', express.static('dist/components/', { etag: false }));


### PR DESCRIPTION
The preview pages for a component which used to be under paths like `/component.html` are now accessed with `/component.preview.html`. This allows requests for static html assets to pass through to the `dist` folder when `TOGA_ASSETS_URL` is set to the same location as the toga server. 

Still got to fix tests and return a promise from the router but it seems to work.