### PR TITLE
The asset-bundles links to static assets snow use an S3 url instead o…

### DIFF
--- a/src/script/webpack/assetUrl.js
+++ b/src/script/webpack/assetUrl.js
@@ -1,11 +1,26 @@
-const { assets } = require('../../app/config/application');
+const { assets, aws } = require('../../app/config/application');
 
-module.exports.assetUrl = () => {
+function cdn() {
   if (assets.url) {
-    return `//${assets.url}`;
+    return `//${assets.url}/`;
   }
   if (assets.host) {
-    return `//${assets.host}/${assets.prefix}`;
+    return `//${assets.host}/${assets.prefix}/`;
   }
   return '';
+}
+
+function s3() {
+  if (assets.url) {
+    return `//${assets.url}/`;
+  }
+  if (aws.bucket) {
+    return `//${aws.bucket}.s3.amazonaws.com/${assets.prefix}/`;
+  }
+  return '';
+}
+
+module.exports = {
+  cdn,
+  s3
 };

--- a/src/script/webpack/createWebpackConfig.js
+++ b/src/script/webpack/createWebpackConfig.js
@@ -6,7 +6,7 @@ const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const AssetsPlugin = require('assets-webpack-plugin');
 const autoprefixer = require('autoprefixer');
 const webpack = require('webpack');
-const {assetUrl} = require('./assetUrl');
+const assetUrl = require('./assetUrl');
 const ProgressBarPlugin = require('progress-bar-webpack-plugin');
 
 const buildHashDeps = {
@@ -31,7 +31,7 @@ module.exports = ({
     output: {
       filename: `[name]-[chunkhash]${minify ? '.min' : ''}.js`,
       path: './dist/components',
-      publicPath: assetUrl() + '/',
+      publicPath: assetUrl.cdn(),
       libraryTarget: (entry && entry.static && staticComponents) ? 'umd': 'var'
     },
     module: {
@@ -103,15 +103,16 @@ module.exports = ({
         processOutput: function(assets) {
           Object.keys(assets)
             .forEach((bundle) => {
-              const url = `${assetUrl()}/`;
-              if (assets[bundle].css && assets[bundle].css.indexOf(url) < 0) {
-                assets[bundle].css = url + assets[bundle].css;
+              const cdnUrl = assetUrl.cdn();
+              const htmlUrl = assetUrl.s3() || assetUrl.cdn();
+              if (assets[bundle].css && assets[bundle].css.indexOf(cdnUrl) < 0) {
+                assets[bundle].css = cdnUrl + assets[bundle].css;
               }
-              if (assets[bundle].js && assets[bundle].js.indexOf(url) < 0) {
-                assets[bundle].js = url + assets[bundle].js;
+              if (assets[bundle].js && assets[bundle].js.indexOf(cdnUrl) < 0) {
+                assets[bundle].js = cdnUrl + assets[bundle].js;
               }
               if (assets[bundle] && staticComponents && staticComponents.includes(bundle)) {
-                assets[bundle].html = `${url}${bundle}-${hash}.html`;
+                assets[bundle].html = `${htmlUrl}${bundle}-${hash}.html`;
               }
             });
           return JSON.stringify(assets);


### PR DESCRIPTION
Links that point to static html assets will now be generated to point to the S3 bucket. As these are only used by the internal network only and do not need to be globally distributed on the CDN having them on the CDN is wasteful in terms of speed/cost and is an additional layer on top of the S3 bucket.