### PR TITLE
add test to ensure state isn't mixed over multiple requests

### DIFF
--- a/tests/e2e/components/test-data/actions/index.js
+++ b/tests/e2e/components/test-data/actions/index.js
@@ -3,21 +3,28 @@ export const FETCH_SWAPI_DATA = 'FETCH_SWAPI_DATA';
 
 const chance = new Chance();
 
+const fullData = (initialState) => {
+  const data = {
+    'name': chance.name(),
+    'height': chance.integer({ min: 90, max: 300 }),
+    'eye_color': chance.color(),
+    'birth_year': chance.birthday().toString(),
+    'gender': chance.gender(),
+    'created': chance.date().toString(),
+    'edited': chance.date().toString(),
+    'url': chance.url()
+  };
+  const props = (initialState && Object.keys(initialState).length > 0)
+    ? JSON.stringify(initialState)
+    : false;
+  return props ? { props, ...data } : data;
+};
+
 export function fetchSwapiData(initialState) {
   return {
     type: FETCH_SWAPI_DATA,
     payload: new Promise((resolve) => {
-      setTimeout(() => resolve({
-        'props': JSON.stringify(initialState),
-        'name': chance.name(),
-        'height': chance.integer({ min: 90, max: 300 }),
-        'eye_color': chance.color(),
-        'birth_year': chance.birthday().toString(),
-        'gender': chance.gender(),
-        'created': chance.date().toString(),
-        'edited': chance.date().toString(),
-        'url': chance.url()
-      }), 350);
+      setTimeout(() => resolve(fullData(initialState)), 350);
     })
   };
 }

--- a/tests/e2e/components/test-data/index.js
+++ b/tests/e2e/components/test-data/index.js
@@ -18,8 +18,8 @@ export default class Root extends React.Component {
   render() {
     return (
       <Provider store={ store }>
-        <Router  >
-          {routes.makeRoutes(this.props)}
+        <Router  {...this.props}>
+          {routes.makeRoutes()}
         </Router>
       </Provider>
     );

--- a/tests/e2e/components/test-data/routes.js
+++ b/tests/e2e/components/test-data/routes.js
@@ -14,14 +14,14 @@ export function getRoutesConfig() {
   ];
 }
 
-export function makeRoutes(props) {
+export function makeRoutes() {
   return (
     <div>
       <Switch>
         {getRoutesConfig().map((route) => (
           <Route {...route}
                  key={route.name}
-                 render={() => <route.Component initialState={ props }/> }
+                 render={() => <route.Component /> }
           />
         ))}
       </Switch>

--- a/tests/e2e/tests/data-with-props.e2e.js
+++ b/tests/e2e/tests/data-with-props.e2e.js
@@ -22,4 +22,11 @@ module.exports = {
     browser.expect.element('.data-list__item--0 .data-list__value').text.to.equal(fakeProps);
   },
 
+  ['data should not carry state from previous render'](browser) {
+    browser.pageLoaded('/data');
+    browser.expect.element('.data-list__item--0').to.be.present;
+    browser.expect.element('.data-list__item--0 .data-list__title').text.not.to.equal('props');
+    browser.expect.element('.data-list__item--0 .data-list__value').text.not.to.equal(fakeProps);
+  },
+
 };


### PR DESCRIPTION
This test checks a component being passed props (via the request url) has props in state and are displayed.
When a second url is navigated to, which doesnt have those props, then the state from the first url is not persisted